### PR TITLE
fix: job model

### DIFF
--- a/app/Models/Job.php
+++ b/app/Models/Job.php
@@ -2,37 +2,10 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 
-class Job {
-    public static function getJobs() : array {
-        return [
-            [
-                'id' => 1,
-                'title' => 'Programmer',
-                'salary' => '$10,000'
-            ],
-            [
-                'id' => 2,
-                'title' => 'Developer',
-                'salary' => '$100,000'
-            ],
-            [
-                'id' => 3,
-                'title' => 'Teacher',
-                'salary' => '$200,000'
-            ]
-        ];
-    }
-    public static function findJob(int $id) : array      {
-        //return Arr::first(Job::getJobs(), fn($job) => $job['id'] == $id );
-        // we changed "Job::all()" to "static:all()" cuz' we're already within the same class
-
-        $job = Arr::first(static::getJobs(), fn($job) => $job['id'] == $id );
-        if ( ! $job ){
-            abort(404, 'Job not found buddy');
-        }
-
-       return $job;
-    }
+class Job extends Model{
+    protected $table = 'job_listings';
+    protected $fillable = ['title','salary'];
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,14 +4,15 @@ use Illuminate\Support\Facades\Route;
 use App\Models\Job;
 
 Route::get('/', function () {
-    return view('home' );
+    dd(Job::all()[2]->salary);
+//    return view('home' );
 });
 Route::get('/jobs', function ()  {
-    return view('jobs', ['jobs' => Job::getJobs()]);
+    return view('jobs', ['jobs' => Job::all()]);
 });
 Route::get('/jobs/{id}', function ($id)  {
 
-     return view('job', ['job' => Job::findJob($id)]);
+     return view('job', ['job' => Job::find($id)]);
 });
 Route::get('/contact', function () {
     return view('contact');


### PR DESCRIPTION
Instead of manually creating the (find, all) functions in the job model, we extend it from the model class. Therefore we can have parent functions from the model class we're extending from. 
learned tinker which is a CLI tool to work with our models and their migrations in the db.
My models will automatically be linked with my tables according to their names if their extending the (model) class (they would automatically do if you run the "php artisan make:model  modelname").